### PR TITLE
Improved implementation

### DIFF
--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -32,7 +32,7 @@ fn get_os(ver: String) -> Type {
     match str::from_utf8(&os.stdout).unwrap() {
         "FreeBSD\n" => {
             let checkHardening = Command::new("sysctl")
-                .arg("-a hardening.version")
+                .arg("hardening.version")
                 .output()
                 .expect("Failed to check if is hardened");
             println!("{:?}", checkHardening);

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -39,6 +39,7 @@ fn get_os(ver: String) -> Type {
                 .arg("$?")
                 .output()
                 .expect("Could not get a return value");
+            println!("{}", isHardened);
             match str::from_utf8(&isHardened.stdout).unwrap() {
                 "0\n" => return Type::HardenedBSD,
                 _ => return Type::FreeBSD,

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -31,11 +31,19 @@ fn get_os(ver: String) -> Type {
 
     match str::from_utf8(&os.stdout).unwrap() {
         "FreeBSD\n" => {
-            if ver.contains("HBSD") {
-                return Type::HardenedBSD;
-            }
-            return Type::FreeBSD;
-        }
+            let checkHardening = Command::new("sysctl")
+                .arg("-a hardeninig")
+                .output()
+                .expect("Failed to check if is hardened");
+            let isHardened = Command::new("echo")
+                .arg("$?")
+                .output()
+                .expect("Could not get a return value");
+            match str::from_utf8(&isHardened.stdout).unwrap() {
+                "0\n" => Type::HardenedBSD,
+                _ => Type::FreeBSD,
+
+        },
         "MidnightBSD\n" => Type::MidnightBSD,
         _ => Type::Unknown,
     }

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -37,7 +37,7 @@ fn get_os(ver: String) -> Type {
                 .expect("Failed to check if is hardened");
             println!("{:?}", checkHardening);
             let isHardened = Command::new("echo")
-                .arg("$?")
+                .arg("$status")
                 .output()
                 .expect("Could not get a return value");
             println!("{:?}", isHardened);

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -13,7 +13,7 @@ pub fn current_platform() -> Info {
         .unwrap_or_else(|| Version::Unknown);
 
     let info = Info {
-        os_type: get_os(version.to_string()),
+        os_type: get_os(),
         version,
         bitness: bitness::get(),
         ..Default::default()

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -35,7 +35,6 @@ fn get_os(ver: String) -> Type {
                 .arg("hardening.version")
                 .output()
                 .expect("Failed to check if is hardened");
-            println!("{:?}", check_hardening);
             match str::from_utf8(&check_hardening.stderr).unwrap() {
                 "" => return Type::HardenedBSD,
                 _ => return Type::FreeBSD,

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -35,6 +35,7 @@ fn get_os(ver: String) -> Type {
                 .arg("-a hardening")
                 .output()
                 .expect("Failed to check if is hardened");
+            println!("{:?}", checkHardening);
             let isHardened = Command::new("echo")
                 .arg("$?")
                 .output()

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -32,7 +32,7 @@ fn get_os(ver: String) -> Type {
     match str::from_utf8(&os.stdout).unwrap() {
         "FreeBSD\n" => {
             let checkHardening = Command::new("sysctl")
-                .arg("-a hardening")
+                .arg("-a hardening.version")
                 .output()
                 .expect("Failed to check if is hardened");
             println!("{:?}", checkHardening);

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -39,7 +39,7 @@ fn get_os(ver: String) -> Type {
                 .arg("$?")
                 .output()
                 .expect("Could not get a return value");
-            println!("{}", isHardened);
+            println!("{:?}", isHardened);
             match str::from_utf8(&isHardened.stdout).unwrap() {
                 "0\n" => return Type::HardenedBSD,
                 _ => return Type::FreeBSD,

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -32,7 +32,7 @@ fn get_os(ver: String) -> Type {
     match str::from_utf8(&os.stdout).unwrap() {
         "FreeBSD\n" => {
             let checkHardening = Command::new("sysctl")
-                .arg("-a hardeninig")
+                .arg("-a hardening")
                 .output()
                 .expect("Failed to check if is hardened");
             let isHardened = Command::new("echo")
@@ -40,9 +40,9 @@ fn get_os(ver: String) -> Type {
                 .output()
                 .expect("Could not get a return value");
             match str::from_utf8(&isHardened.stdout).unwrap() {
-                "0\n" => Type::HardenedBSD,
-                _ => Type::FreeBSD,
-
+                "0\n" => return Type::HardenedBSD,
+                _ => return Type::FreeBSD,
+            }
         },
         "MidnightBSD\n" => Type::MidnightBSD,
         _ => Type::Unknown,

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -23,7 +23,7 @@ pub fn current_platform() -> Info {
     info
 }
 
-fn get_os(ver: String) -> Type {
+fn get_os() -> Type {
     let os = Command::new("uname")
         .arg("-s")
         .output()

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -31,18 +31,13 @@ fn get_os(ver: String) -> Type {
 
     match str::from_utf8(&os.stdout).unwrap() {
         "FreeBSD\n" => {
-            let checkHardening = Command::new("sysctl")
+            let check_hardening = Command::new("sysctl")
                 .arg("hardening.version")
                 .output()
                 .expect("Failed to check if is hardened");
-            println!("{:?}", checkHardening);
-            let isHardened = Command::new("echo")
-                .arg("$status")
-                .output()
-                .expect("Could not get a return value");
-            println!("{:?}", isHardened);
-            match str::from_utf8(&isHardened.stdout).unwrap() {
-                "0\n" => return Type::HardenedBSD,
+            println!("{:?}", check_hardening);
+            match str::from_utf8(&check_hardening.stderr).unwrap() {
+                "" => return Type::HardenedBSD,
                 _ => return Type::FreeBSD,
             }
         },


### PR DESCRIPTION
This implementation is agnostic to whether a non-standard HardenedBSD kernel has been compiled. Checks to see if `hardening.version` is present in `sysctl.` This field only occurs on HardenedBSD kernels. Checks stderr, if stderr is blank, HardenedBSD, if stderr is not blank, FreeBSD.
